### PR TITLE
Disable "use strict" since it breaks iOS webpacks.

### DIFF
--- a/nativescript-background-http/tsconfig.json
+++ b/nativescript-background-http/tsconfig.json
@@ -7,6 +7,7 @@
 		"preserveConstEnums": true,
 		"sourceMap": false,
 		"declaration": false,
+		"noImplicitUseStrict": true,
 		"experimentalDecorators": true,
 		"lib": [
 			"es2016"


### PR DESCRIPTION
Addresses #33 