### PR TITLE
Supporting webpack

### DIFF
--- a/nativescript-background-http/package.json
+++ b/nativescript-background-http/package.json
@@ -11,7 +11,7 @@
       "android": "2.4.1"
     }
   },
-  "main": "background-http.js",
+  "main": "background-http",
   "homepage": "http://nativescript.github.io/nativescript-background-http/",
   "url": "https://github.com/NativeScript/nativescript-background-http/issues",
   "license": "Apache-2.0",


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson