### PR TITLE
support for android sdk 26

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -2,9 +2,11 @@ import application = require("application");
 import { Observable } from "data/observable";
 import { ad } from "utils/utils";
 import * as fileSystemModule from "file-system";
+import { isAndroid, device } from 'platform';
 import * as common from "./index";
 
 declare const net: any;
+declare const android: any;
 net.gotev.uploadservice.UploadService.NAMESPACE = application.android.packageName;
 
 interface UploadInfo {
@@ -138,8 +140,17 @@ class Task extends ObservableBase {
         request.setFileToUpload(file);
 
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
+
+        if (isAndroid && parseInt(device.sdkVersion) >= 26) {
+            const channel = new android.app.NotificationChannel(application.android.packageName, application.android.packageName, android.app.NotificationManager.IMPORTANCE_LOW);
+            const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+            notificationManager.createNotificationChannel(channel);
+        }
+
         if (displayNotificationProgress) {
-            request.setNotificationConfig(new net.gotev.uploadservice.UploadNotificationConfig());
+            const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
+            uploadNotificationConfig.setNotificationChannelId(application.android.packageName);
+            request.setNotificationConfig(uploadNotificationConfig);
         }
         const autoDeleteAfterUpload = typeof options.androidAutoDeleteAfterUpload === "boolean" ? options.androidAutoDeleteAfterUpload : false;
         if (autoDeleteAfterUpload) {


### PR DESCRIPTION
I was unable to use this plugin with Android 8.0, as mentioned in #117 and #124 ; this solved my problem so it can be a base for your own solution (and if everyone looks good for you, you can even accept this PR).

The idea is simple, for the SDK 26+ we create the notification channel such that we don't have a null channel; we set the already existing config to use the channel we previously created.