### PR TITLE
Update to create a notification channel for SDK 26 and up

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -4,10 +4,13 @@ import { ad } from "utils/utils";
 import * as fileSystemModule from "file-system";
 import * as common from "./index";
 
+declare const android: any;
+
 type Context = android.content.Context;
 type ServerResponse = net.gotev.uploadservice.ServerResponse;
 type UploadInfo = net.gotev.uploadservice.UploadInfo;
 type UploadServiceBroadcastReceiver = net.gotev.uploadservice.UploadServiceBroadcastReceiver;
+type UploadNotificationConfig = net.gotev.uploadservice.UploadNotificationConfig;
 
 /* A snapshot-friendly, lazy-loaded class for ProgressReceiver BEGIN */
 let ProgressReceiver: any;
@@ -186,19 +189,7 @@ class Task extends ObservableBase {
 
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
         if (displayNotificationProgress) {
-
-            const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
-            if(android.os.Build.VERSION.SDK_INT >= 26){
-                const channel = new android.app.NotificationChannel(application.android.packageName, 
-                                application.android.packageName,
-                                android.app.NotificationManager.IMPORTANCE_LOW);
-                                
-                const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
-                notificationManager.createNotificationChannel(channel);
-                
-                uploadNotificationConfig.setNotificationChannelId(application.android.packageName)
-            }
-            request.setNotificationConfig(uploadNotificationConfig);
+            request.setNotificationConfig(Task.getUploadNotificationConfig(context));
         }
 
         const autoDeleteAfterUpload = typeof options.androidAutoDeleteAfterUpload === "boolean" ? options.androidAutoDeleteAfterUpload : false;
@@ -269,19 +260,7 @@ class Task extends ObservableBase {
 
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
         if (displayNotificationProgress) {
-
-            const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
-            if(android.os.Build.VERSION.SDK_INT >= 26){
-                const channel = new android.app.NotificationChannel(application.android.packageName, 
-                                application.android.packageName,
-                                android.app.NotificationManager.IMPORTANCE_LOW);
-                                
-                const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
-                notificationManager.createNotificationChannel(channel);
-                
-                uploadNotificationConfig.setNotificationChannelId(application.android.packageName)
-            }
-            request.setNotificationConfig(uploadNotificationConfig);
+            request.setNotificationConfig(Task.getUploadNotificationConfig(context));
         }
 
         const headers = options.headers;
@@ -354,5 +333,21 @@ class Task extends ObservableBase {
     }
     cancel(): void {
         (<any>net).gotev.uploadservice.UploadService.stopUpload(this._id);
+    }
+
+    private static getUploadNotificationConfig(context: Context): UploadNotificationConfig {
+
+        const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
+        if(android.os.Build.VERSION.SDK_INT >= 26){
+            const channel = new android.app.NotificationChannel(application.android.packageName, 
+                            application.android.packageName,
+                            android.app.NotificationManager.IMPORTANCE_LOW);
+                            
+            const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+            notificationManager.createNotificationChannel(channel);
+            
+            uploadNotificationConfig.setNotificationChannelId(application.android.packageName)
+        }
+        return uploadNotificationConfig;
     }
 }

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -186,8 +186,21 @@ class Task extends ObservableBase {
 
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
         if (displayNotificationProgress) {
-            request.setNotificationConfig(new net.gotev.uploadservice.UploadNotificationConfig());
+
+            const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
+            if(android.os.Build.VERSION.SDK_INT >= 26){
+                const channel = new android.app.NotificationChannel(application.android.packageName, 
+                                application.android.packageName,
+                                android.app.NotificationManager.IMPORTANCE_LOW);
+                                
+                const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+                notificationManager.createNotificationChannel(channel);
+                
+                uploadNotificationConfig.setNotificationChannelId(application.android.packageName)
+            }
+            request.setNotificationConfig(uploadNotificationConfig);
         }
+
         const autoDeleteAfterUpload = typeof options.androidAutoDeleteAfterUpload === "boolean" ? options.androidAutoDeleteAfterUpload : false;
         if (autoDeleteAfterUpload) {
             request.setAutoDeleteFilesAfterSuccessfulUpload(true);
@@ -256,7 +269,19 @@ class Task extends ObservableBase {
 
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
         if (displayNotificationProgress) {
-            request.setNotificationConfig(new net.gotev.uploadservice.UploadNotificationConfig());
+
+            const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
+            if(android.os.Build.VERSION.SDK_INT >= 26){
+                const channel = new android.app.NotificationChannel(application.android.packageName, 
+                                application.android.packageName,
+                                android.app.NotificationManager.IMPORTANCE_LOW);
+                                
+                const notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+                notificationManager.createNotificationChannel(channel);
+                
+                uploadNotificationConfig.setNotificationChannelId(application.android.packageName)
+            }
+            request.setNotificationConfig(uploadNotificationConfig);
         }
 
         const headers = options.headers;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ N/A] All existing tests are passing
- [ N/A] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
[#136](https://github.com/NativeScript/nativescript-background-http/issues/136)
[#124](https://github.com/NativeScript/nativescript-background-http/issues/124)

## What is the new behavior?
<!-- Describe the changes. -->
Updated background-http.android.ts to check the current SDK version.  If SDK 26 or higher, a default notification channel is created and set in the notification config.

This update has been tested on a Samsung S8 emulator running Android 8 and a Samsung S6 running Android 7.  

One thing to note, I tried to use the Build.VERSION_CODES.O constant but it didn't seem to work when running on a Samsung S6 with Android 7. 

Fixes/Implements/Closes #[136].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

