### PR TITLE
fix: unintentional breaking change in previous release

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -74,7 +74,8 @@ function onProgressReceiverCompleted(context: Context, uploadInfo: UploadInfo, r
     task.notify(<common.CompleteEventData>{
       eventName: "complete",
       object: task,
-      responseCode: response && typeof response.getHttpCode === 'function' ? response.getHttpCode() : -1
+      responseCode: response && typeof response.getHttpCode === 'function' ? response.getHttpCode() : -1,
+      response
     });
 }
 


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
The complete event doesn't expose the full response but only its response code

## What is the new behavior?
The complete event now exposes the full response and not only its response code

Related to #143.