### PR TITLE
Specify the type of session.multipartUpload options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -133,7 +133,7 @@ export interface Session {
      * @param options Options for the upload, sets uri, headers, task description etc.
      */
     uploadFile(fileUri: string, options: Request): Task;
-    multipartUpload(params: Array<any>, options: any): Task;
+    multipartUpload(params: Array<any>, options: Request): Task;
 
 }
 


### PR DESCRIPTION
Looking at the iOS and Android implementations, the type of `options` is `Request`, so no need for `any`. This makes my IDE happy.. and a happy IDE is a happy developer 😃