### PR TITLE
added option to change maxRetryCount on Android devices

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -195,6 +195,10 @@ class Task extends ObservableBase {
         if (autoDeleteAfterUpload) {
             request.setAutoDeleteFilesAfterSuccessfulUpload(true);
         }
+        const maxRetryCount = typeof options.androidMaxRetries === "number" ? options.androidMaxRetries : undefined;
+        if (maxRetryCount) {
+            request.setMaxRetries(maxRetryCount);
+        }
 
         const headers = options.headers;
         if (headers) {
@@ -262,6 +266,14 @@ class Task extends ObservableBase {
         const displayNotificationProgress = typeof options.androidDisplayNotificationProgress === "boolean" ? options.androidDisplayNotificationProgress : true;
         if (displayNotificationProgress) {
             request.setNotificationConfig(new net.gotev.uploadservice.UploadNotificationConfig());
+        }
+        const autoDeleteAfterUpload = typeof options.androidAutoDeleteAfterUpload === "boolean" ? options.androidAutoDeleteAfterUpload : false;
+        if (autoDeleteAfterUpload) {
+            request.setAutoDeleteFilesAfterSuccessfulUpload(true);
+        }
+        const maxRetryCount = typeof options.androidMaxRetries === "number" ? options.androidMaxRetries : undefined;
+        if (maxRetryCount) {
+            request.setMaxRetries(maxRetryCount);
         }
 
         const headers = options.headers;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -180,4 +180,10 @@ export interface Request {
      * Use this to set if files should be deleted automatically after upload
      */
     androidAutoDeleteAfterUpload?: boolean;
+
+    /*
+    * Use this to set the maximum retry count. The default retry count is 0
+    * https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
+    */
+    androidMaxRetries?: number;
 }


### PR DESCRIPTION
Co-Authored-By: Icer2000 <andre.huehn81@gmail.com>

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the connection is lost during an upload the upload fails on android devices
## What is the new behavior?
If the androidMaxRetries options is set to a value greater than 0, the upload continues on its own for the specified count .

Additionally the autoDeleteAfterUpload option is included in multipart upload



