### PR TITLE
fix(src/index.d.ts): Added response missing field to ErrorEventData interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,9 @@ export interface ErrorEventData extends observable.EventData {
     error: any /*NSError | java.lang.Exception*/;
     /** HTTP response code if response object is present, otherwise -1 */
     responseCode: number;
+
+    // The response from server
+    response: net.gotev.uploadservice.ServerResponse
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export interface ErrorEventData extends observable.EventData {
     responseCode: number;
 
     // The response from server
-    response: net.gotev.uploadservice.ServerResponse
+    response: any; // net.gotev.uploadservice.ServerResponse
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
All uses of ErrorEventData are passing a property named response but it's existance in the ErrorEventData interface is missing.

## What is the new behavior?
The interface now has a field named response with type any as this object comes from the Java runtime
