### PR TITLE
Attempt to fix iOS error where no response is available.

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -131,7 +131,7 @@ function ensureReceiver() {
     }
 }
 
-export function session(id: string) {
+export function session(id: string, foreground?: boolean) {
     // TODO: Cache.
     return new Session(id);
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,8 +3,9 @@ import * as observable from "tns-core-modules/data/observable";
 /**
  * Get or create a background download/upload session by id.
  * @param id The session id.
+ * @param foreground iOS only, create a foreground session (allows workaround for response statusCode)
  */
-export function session(id: string): Session;
+export function session(id: string, foreground?: boolean): Session;
 
 /**
  * Provides error information for error notifications.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
On iOS the ``response`` is always ``null`` and ``responseCode`` always ``-1``. So we can't tell if the upload was successful. 

## What is the new behavior?
I've added a parameter when creating a session on iOS to cause it to use the default session instead of a background session.
```typescript
export function session(id: string, foreground?: boolean)
```
When setting this new option to ``true``, the response will be passed through as expected. With the caveat the the session will not operate in background mode.

Further details of my changes and rationale can be found in the commit message.

Creates workaround for #214 .

BREAKING CHANGES:
- Using the foreground option on iOS will cause the session to operate in the default mode, rather than background. Meaning it is not a solution for people specifically looking for background uploads.
- I've also reorganized when the "responded" event fires to line up with the android behavior. I don't think this is likely to cause problems.

