### PR TITLE
Tbozhikov/fix response code ios

### DIFF
--- a/demo-angular/app/home/home.component.ts
+++ b/demo-angular/app/home/home.component.ts
@@ -89,7 +89,8 @@ export class HomeComponent {
                     error: e.error ? e.error.toString() : e.error,
                     currentBytes: e.currentBytes,
                     totalBytes: e.totalBytes,
-                    body: e.data
+                    body: e.data,
+                    responseCode: e.responseCode
                 })
             });
         }

--- a/demo-angular/nsconfig.json
+++ b/demo-angular/nsconfig.json
@@ -1,0 +1,3 @@
+{
+	"useLegacyWorkflow": false
+}

--- a/demo-vue/app/components/Home.vue
+++ b/demo-vue/app/components/Home.vue
@@ -114,7 +114,8 @@ export default {
             error: e.error ? e.error.toString() : e.error,
             currentBytes: e.currentBytes,
             totalBytes: e.totalBytes,
-            body: e.data
+            body: e.data,
+            responseCode: e.responseCode
           })
         });
 

--- a/demo-vue/nsconfig.json
+++ b/demo-vue/nsconfig.json
@@ -1,0 +1,3 @@
+{
+	"useLegacyWorkflow": false
+}

--- a/demo/app/home/home-view-model.ts
+++ b/demo/app/home/home-view-model.ts
@@ -89,7 +89,8 @@ export class HomeViewModel extends Observable {
                     error: e.error ? e.error.toString() : e.error,
                     currentBytes: e.currentBytes,
                     totalBytes: e.totalBytes,
-                    body: e.data
+                    body: e.data,
+                    responseCode: e.responseCode
                 })
             });
         }

--- a/demo/nsconfig.json
+++ b/demo/nsconfig.json
@@ -1,0 +1,3 @@
+{
+	"useLegacyWorkflow": false
+}

--- a/src/background-http.ios.ts
+++ b/src/background-http.ios.ts
@@ -25,7 +25,7 @@ function onError(session, nsTask, error) {
         const fileManager = utils.ios.getter(NSFileManager, NSFileManager.defaultManager);
         fileManager.removeItemAtPathError(task._fileToCleanup);
     }
-    let response = nsTask && nsTask.performSelector("response") ? <NSHTTPURLResponse>nsTask.performSelector("response") : null;
+    const response = nsTask && <NSHTTPURLResponse>nsTask.performSelector("response");
     if (error) {
         task.notifyPropertyChange("status", task.status);
         task.notify(<common.ErrorEventData>{
@@ -318,19 +318,6 @@ class Task extends Observable {
 
     public cancel(): void {
         this._task.cancel();
-    }
-
-    private readProp<T>(object: NSObject, prop: string, type: interop.Type<T>): T {
-        const sig = object.methodSignatureForSelector(prop);
-        const invocation = NSInvocation.invocationWithMethodSignature(sig);
-        invocation.selector = prop;
-
-        invocation.invokeWithTarget(object);
-
-        const ret = new interop.Reference<T>(type, new interop.Pointer());
-        invocation.getReturnValue(ret);
-
-        return ret.value;
     }
 }
 

--- a/src/background-http.ios.ts
+++ b/src/background-http.ios.ts
@@ -233,7 +233,7 @@ class Session implements common.Session {
 }
 
 class NativePropertyReader {
-    public _invocationCache = new Map<string, NSInvocation>();
+    private _invocationCache = new Map<string, NSInvocation>();
 
     private getInvocationObject(object: NSObject, selector: string): NSInvocation {
         let invocation = this._invocationCache.get(selector);
@@ -315,6 +315,7 @@ class Task extends Observable {
 
         return task;
     }
+
     public cancel(): void {
         this._task.cancel();
     }

--- a/src/background-http.ios.ts
+++ b/src/background-http.ios.ts
@@ -25,7 +25,7 @@ function onError(session, nsTask, error) {
         const fileManager = utils.ios.getter(NSFileManager, NSFileManager.defaultManager);
         fileManager.removeItemAtPathError(task._fileToCleanup);
     }
-    let response = nsTask && nsTask.response ? <NSHTTPURLResponse>nsTask.response : null;
+    let response = nsTask && nsTask.performSelector("response") ? <NSHTTPURLResponse>nsTask.performSelector("response") : null;
     if (error) {
         task.notifyPropertyChange("status", task.status);
         task.notify(<common.ErrorEventData>{
@@ -61,20 +61,15 @@ class BackgroundUploadDelegate extends NSObject implements NSURLSessionDelegate,
 
     // NSURLSessionDelegate
     URLSessionDidBecomeInvalidWithError(session, error) {
-        // console.log("URLSessionDidBecomeInvalidWithError:");
-        // console.log(" - session: " + session);
-        // console.log(" - error:   " + error);
     }
 
     URLSessionDidReceiveChallengeCompletionHandler(session, challenge, comlpetionHandler) {
-        // console.log("URLSessionDidFinishEventsForBackgroundURLSession: " + session + " " + challenge);
         const disposition = null;
         const credential = null;
         comlpetionHandler(disposition, credential);
     }
 
     URLSessionDidFinishEventsForBackgroundURLSession(session) {
-        // console.log("URLSessionDidFinishEventsForBackgroundURLSession: " + session);
     }
 
     // NSURLSessionTaskDelegate
@@ -85,7 +80,6 @@ class BackgroundUploadDelegate extends NSObject implements NSURLSessionDelegate,
     }
 
     URLSessionTaskDidReceiveChallengeCompletionHandler(session, task, challenge, completionHandler) {
-        // console.log("URLSessionTaskDidReceiveChallengeCompletionHandler: " + session + " " + task + " " + challenge);
         const disposition = null;
         const credential = null;
         completionHandler(disposition, credential);
@@ -98,28 +92,23 @@ class BackgroundUploadDelegate extends NSObject implements NSURLSessionDelegate,
     }
 
     URLSessionTaskNeedNewBodyStream(session, task, need) {
-        // console.log("URLSessionTaskNeedNewBodyStream");
     }
 
     URLSessionTaskWillPerformHTTPRedirectionNewRequestCompletionHandler(session, task, redirect, request, completionHandler) {
-        // console.log("URLSessionTaskWillPerformHTTPRedirectionNewRequestCompletionHandler");
         completionHandler(request);
     }
 
     // NSURLSessionDataDelegate
     URLSessionDataTaskDidReceiveResponseCompletionHandler(session, dataTask, response, completionHandler) {
-        // console.log("URLSessionDataTaskDidReceiveResponseCompletionHandler");
         const disposition = null;
         completionHandler(disposition);
     }
 
     URLSessionDataTaskDidBecomeDownloadTask(session, dataTask, downloadTask) {
-        // console.log("URLSessionDataTaskDidBecomeDownloadTask");
     }
 
     URLSessionDataTaskDidReceiveData(session: NSURLSession, dataTask: NSURLSessionDataTask, data: NSData) {
         dispatch_async(main_queue, () => {
-            // console.log("URLSessionDataTaskDidReceiveData");
             // we have a response in the data...
             const jsTask = Task.getTask(session, dataTask);
             const jsonString = NSString.alloc().initWithDataEncoding(data, NSUTF8StringEncoding);
@@ -134,20 +123,16 @@ class BackgroundUploadDelegate extends NSObject implements NSURLSessionDelegate,
     }
 
     URLSessionDataTaskWillCacheResponseCompletionHandler() {
-        // console.log("URLSessionDataTaskWillCacheResponseCompletionHandler");
     }
 
     // NSURLSessionDownloadDelegate
     URLSessionDownloadTaskDidResumeAtOffsetExpectedTotalBytes(session, task, offset, expects) {
-        // console.log("URLSessionDownloadTaskDidResumeAtOffsetExpectedTotalBytes");
     }
 
     URLSessionDownloadTaskDidWriteDataTotalBytesWrittenTotalBytesExpectedToWrite(session, task, data, written, expected) {
-        // console.log("URLSessionDownloadTaskDidWriteDataTotalBytesWrittenTotalBytesExpectedToWrite");
     }
 
     URLSessionDownloadTaskDidFinishDownloadingToURL(session, task, url) {
-        // console.log("URLSessionDownloadTaskDidFinishDownloadingToURL");
     }
 }
 
@@ -247,8 +232,38 @@ class Session implements common.Session {
     }
 }
 
+class NativePropertyReader {
+    public _invocationCache = new Map<string, NSInvocation>();
+
+    private getInvocationObject(object: NSObject, selector: string): NSInvocation {
+        let invocation = this._invocationCache.get(selector);
+        if (!invocation) {
+            const sig = object.methodSignatureForSelector(selector);
+            invocation = NSInvocation.invocationWithMethodSignature(sig);
+            invocation.selector = selector;
+
+            this._invocationCache[selector] = invocation;
+        }
+
+        return invocation;
+    }
+
+    public readProp<T>(object: NSObject, prop: string, type: interop.Type<T>): T {
+        const invocation = this.getInvocationObject(object, prop);
+        invocation.invokeWithTarget(object);
+
+        const ret = new interop.Reference<T>(type, new interop.Pointer());
+        invocation.getReturnValue(ret);
+
+        return ret.value;
+    }
+}
+
 class Task extends Observable {
     public static _tasks = new Map<NSURLSessionTask, Task>();
+    public static tasksReader = new NativePropertyReader();
+    private static is64BitArchitecture = interop.sizeof(interop.types.id) === 8;
+    public static NSIntegerType = Task.is64BitArchitecture ? interop.types.int64 : interop.types.int32;
 
     public _fileToCleanup: string;
     private _task: NSURLSessionTask;
@@ -269,18 +284,19 @@ class Task extends Observable {
     }
 
     get upload(): number {
-        return this._task.countOfBytesSent;
+        return Task.tasksReader.readProp(this._task, "countOfBytesSent", interop.types.int64);
     }
 
     get totalUpload(): number {
-        return this._task.countOfBytesExpectedToSend;
+        return Task.tasksReader.readProp(this._task, "countOfBytesExpectedToSend", interop.types.int64);
     }
 
     get status(): string {
-        if (this._task.error) {
+        if (Task.tasksReader.readProp(this._task, "error", Task.NSIntegerType)) {
             return "error";
         }
-        switch (this._task.state) {
+        // NSURLSessionTaskState : NSInteger, so we should pass number format here
+        switch (Task.tasksReader.readProp(this._task, "state", Task.NSIntegerType) as NSURLSessionTaskState) {
             case NSURLSessionTaskState.Running: return "uploading";
             case NSURLSessionTaskState.Completed: return "complete";
             case NSURLSessionTaskState.Canceling: return "error";
@@ -301,6 +317,19 @@ class Task extends Observable {
     }
     public cancel(): void {
         this._task.cancel();
+    }
+
+    private readProp<T>(object: NSObject, prop: string, type: interop.Type<T>): T {
+        const sig = object.methodSignatureForSelector(prop);
+        const invocation = NSInvocation.invocationWithMethodSignature(sig);
+        invocation.selector = prop;
+
+        invocation.invokeWithTarget(object);
+
+        const ret = new interop.Reference<T>(type, new interop.Pointer());
+        invocation.getReturnValue(ret);
+
+        return ret.value;
     }
 }
 


### PR DESCRIPTION
## What is the current behavior?
After iOS runtime 5.3 was released some of the properties of the event arguments returned by the plugin are undefined/unset/incorrect values. Such is the `responseCode` property as described in https://github.com/NativeScript/nativescript-background-http/issues/214

The iOS Runtime bug related to this is:
https://github.com/NativeScript/ios-runtime/issues/1149

## What is the new behavior?
<!-- Describe the changes. -->

With this PR, some of the native iOS properties that were unable to be read after iOS Runtime v5.3 are now read in different ways:

- using the `NativePropertyReader` class and its usage
- using `<native-iOS-instance>.performSelector("<property-name>")`
