### PR TITLE
feat(android): add options to set notifications channel id, ringtone enabled and auto clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ androidDisplayNotificationProgress | `boolean` | (Android only) Used to set if p
 androidNotificationTitle | `string` | (Android only) Used to set the title shown in the Android notifications center.
 androidAutoDeleteAfterUpload | `boolean` | (Android only) Used to set if files should be deleted automatically after upload.
 androidMaxRetries | `number` | (Android only) Used to set the maximum retry count. The default retry count is 0. https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
+androidAutoClearNotification | `boolean` | (Android only) Used to set if notifications should be cleared automatically upon upload completion. Default is false.
 
 The task object has the following properties and methods, that can be used to get information about the upload:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ androidNotificationTitle | `string` | (Android only) Used to set the title shown
 androidAutoDeleteAfterUpload | `boolean` | (Android only) Used to set if files should be deleted automatically after upload.
 androidMaxRetries | `number` | (Android only) Used to set the maximum retry count. The default retry count is 0. https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
 androidAutoClearNotification | `boolean` | (Android only) Used to set if notifications should be cleared automatically upon upload completion. Default is false.
+androidRingToneEnabled | `boolean` | (Android only) Used to set if a ringtone should be played upon upload completion. Default is true.
 
 The task object has the following properties and methods, that can be used to get information about the upload:
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ androidDisplayNotificationProgress | `boolean` | (Android only) Used to set if p
 androidNotificationTitle | `string` | (Android only) Used to set the title shown in the Android notifications center.
 androidAutoDeleteAfterUpload | `boolean` | (Android only) Used to set if files should be deleted automatically after upload.
 androidMaxRetries | `number` | (Android only) Used to set the maximum retry count. The default retry count is 0. https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
-androidAutoClearNotification | `boolean` | (Android only) Used to set if notifications should be cleared automatically upon upload completion. Default is false.
-androidRingToneEnabled | `boolean` | (Android only) Used to set if a ringtone should be played upon upload completion. Default is true.
+androidAutoClearNotification | `boolean` | (Android only) Used to set if notifications should be cleared automatically upon upload completion. Default is false. Please note that setting this to true will also disable the ringtones.
+androidRingToneEnabled | `boolean` | (Android only) Used to set if a ringtone should be played upon upload completion. Default is true. Please note that this flag has no effect when `androidAutoClearNotification` is set to true.
 androidNotificationChannelID | `string` | (Android only) Used to set the channel ID for the notifications.
 
 The task object has the following properties and methods, that can be used to get information about the upload:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ androidAutoDeleteAfterUpload | `boolean` | (Android only) Used to set if files s
 androidMaxRetries | `number` | (Android only) Used to set the maximum retry count. The default retry count is 0. https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
 androidAutoClearNotification | `boolean` | (Android only) Used to set if notifications should be cleared automatically upon upload completion. Default is false.
 androidRingToneEnabled | `boolean` | (Android only) Used to set if a ringtone should be played upon upload completion. Default is true.
+androidNotificationChannelID | `string` | (Android only) Used to set the channel ID for the notifications.
 
 The task object has the following properties and methods, that can be used to get information about the upload:
 

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -307,7 +307,16 @@ function setRequestOptions(request: any, options: common.Request) {
     if (displayNotificationProgress) {
         const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
         const notificationTitle = typeof options.androidNotificationTitle === "string" ? options.androidNotificationTitle : 'File Upload';
+        const autoClearNotifications = typeof options.androidAutoClearNotification === "boolean" ? options.androidAutoClearNotification : false;
+
         uploadNotificationConfig.setTitleForAllStatuses(notificationTitle);
+
+        if (autoClearNotifications) {
+            uploadNotificationConfig.getCompleted().autoClear = autoClearNotifications;
+            uploadNotificationConfig.getCancelled().autoClear = autoClearNotifications;
+            uploadNotificationConfig.getError().autoClear = autoClearNotifications;
+        }
+
         request.setNotificationConfig(uploadNotificationConfig);
     }
     const autoDeleteAfterUpload = typeof options.androidAutoDeleteAfterUpload === "boolean" ? options.androidAutoDeleteAfterUpload : false;

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -307,20 +307,22 @@ function setRequestOptions(request: any, options: common.Request) {
     if (displayNotificationProgress) {
         const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
         const notificationTitle = typeof options.androidNotificationTitle === "string" ? options.androidNotificationTitle : 'File Upload';
-        const autoClearNotifications = typeof options.androidAutoClearNotification === "boolean" ? options.androidAutoClearNotification : false;
-        const ringToneEnabled = typeof options.androidRingToneEnabled === "boolean" ? options.androidRingToneEnabled : true;
-        const channelID = typeof options.androidNotificationChannelID === "string" ? options.androidNotificationChannelID : undefined;
 
         uploadNotificationConfig.setTitleForAllStatuses(notificationTitle);
-        uploadNotificationConfig.setRingToneEnabled(new java.lang.Boolean(ringToneEnabled));
 
-        if (channelID) {
-            uploadNotificationConfig.setNotificationChannelId(channelID);
+        if (typeof options.androidRingToneEnabled === "boolean") {
+            uploadNotificationConfig.setRingToneEnabled(new java.lang.Boolean(options.androidRingToneEnabled));
         }
 
-        uploadNotificationConfig.getCompleted().autoClear = autoClearNotifications;
-        uploadNotificationConfig.getCancelled().autoClear = autoClearNotifications;
-        uploadNotificationConfig.getError().autoClear = autoClearNotifications;
+        if (typeof options.androidAutoClearNotification === "boolean") {
+            uploadNotificationConfig.getCompleted().autoClear = options.androidAutoClearNotification;
+            uploadNotificationConfig.getCancelled().autoClear = options.androidAutoClearNotification;
+            uploadNotificationConfig.getError().autoClear = options.androidAutoClearNotification;
+        }
+
+        if (typeof options.androidNotificationChannelID === "string" && options.androidNotificationChannelID) {
+            uploadNotificationConfig.setNotificationChannelId(options.androidNotificationChannelID);
+        }
 
         request.setNotificationConfig(uploadNotificationConfig);
     }

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -309,9 +309,14 @@ function setRequestOptions(request: any, options: common.Request) {
         const notificationTitle = typeof options.androidNotificationTitle === "string" ? options.androidNotificationTitle : 'File Upload';
         const autoClearNotifications = typeof options.androidAutoClearNotification === "boolean" ? options.androidAutoClearNotification : false;
         const ringToneEnabled = typeof options.androidRingToneEnabled === "boolean" ? options.androidRingToneEnabled : true;
+        const channelID = typeof options.androidNotificationChannelID === "string" ? options.androidNotificationChannelID : undefined;
 
         uploadNotificationConfig.setTitleForAllStatuses(notificationTitle);
         uploadNotificationConfig.setRingToneEnabled(new java.lang.Boolean(ringToneEnabled));
+
+        if (channelID) {
+            uploadNotificationConfig.setNotificationChannelId(channelID);
+        }
 
         uploadNotificationConfig.getCompleted().autoClear = autoClearNotifications;
         uploadNotificationConfig.getCancelled().autoClear = autoClearNotifications;

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -308,14 +308,14 @@ function setRequestOptions(request: any, options: common.Request) {
         const uploadNotificationConfig = new net.gotev.uploadservice.UploadNotificationConfig();
         const notificationTitle = typeof options.androidNotificationTitle === "string" ? options.androidNotificationTitle : 'File Upload';
         const autoClearNotifications = typeof options.androidAutoClearNotification === "boolean" ? options.androidAutoClearNotification : false;
+        const ringToneEnabled = typeof options.androidRingToneEnabled === "boolean" ? options.androidRingToneEnabled : true;
 
         uploadNotificationConfig.setTitleForAllStatuses(notificationTitle);
+        uploadNotificationConfig.setRingToneEnabled(new java.lang.Boolean(ringToneEnabled));
 
-        if (autoClearNotifications) {
-            uploadNotificationConfig.getCompleted().autoClear = autoClearNotifications;
-            uploadNotificationConfig.getCancelled().autoClear = autoClearNotifications;
-            uploadNotificationConfig.getError().autoClear = autoClearNotifications;
-        }
+        uploadNotificationConfig.getCompleted().autoClear = autoClearNotifications;
+        uploadNotificationConfig.getCancelled().autoClear = autoClearNotifications;
+        uploadNotificationConfig.getError().autoClear = autoClearNotifications;
 
         request.setNotificationConfig(uploadNotificationConfig);
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -199,4 +199,9 @@ export interface Request {
      * Use this to set if notifications should be cleared automatically upon upload completion
      */
     androidAutoClearNotification?: boolean;
+
+    /*
+     * Use this to set if a ringtone should be played upon upload completion
+     */
+    androidRingToneEnabled?: boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -85,12 +85,12 @@ export interface Task {
      * Cancel the Upload Task.
      */
     cancel(): void;
-   /**
-     * Subscribe for a general event.
-     * @param event The name of the event to subscribe for.
-     * @param handler The handler called when the event occure.
-     * @event
-     */
+    /**
+      * Subscribe for a general event.
+      * @param event The name of the event to subscribe for.
+      * @param handler The handler called when the event occure.
+      * @event
+      */
     on(event: string, handler: (e: observable.EventData) => void): void;
 
     /**
@@ -194,4 +194,9 @@ export interface Request {
     * https://github.com/gotev/android-upload-service/wiki/Recipes#backoff
     */
     androidMaxRetries?: number;
+
+    /*
+     * Use this to set if notifications should be cleared automatically upon upload completion
+     */
+    androidAutoClearNotification?: boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -204,4 +204,9 @@ export interface Request {
      * Use this to set if a ringtone should be played upon upload completion
      */
     androidRingToneEnabled?: boolean;
+
+    /*
+     * Use this to set the channel ID for the notifications
+     */
+    androidNotificationChannelID?: string;
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, there is no way of changing some options of upload notifications that are available on android upload service.

## What is the new behavior?
<!-- Describe the changes. -->
Three new fields were implemented to allow changing these settings, `androidRingToneEnabled` `androidNotificationChannelID` and `androidAutoClearNotification`

The changes made were based off on #71

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

