### PR TITLE
[feat](ios) Add ios assets-library url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ The plugin uses [NSURLSession with background session configuration for iOS](htt
 tns plugin add nativescript-background-http
 ```
 
+## Breaking Change
+In v5.0 `.uploadFile` and `.multipartUpload` returns a promise with the task instead of a task directly.
+This is to allow ios "assets-library" urls to be uploaded (& easily in future ios PHAsset urls).
+
+
 ## Usage
 
 The below attached code snippets demonstrate how to use `nativescript-background-http` to upload single or multiple files.
+
 
 ### Uploading files
 
@@ -23,14 +29,14 @@ Sample code for configuring the upload session. Each session must have a unique 
 ```JavaScript
 
 // file path and url
-var file =  "/some/local/file/path/and/file/name.jpg";
-var url = "https://some.remote.service.com/path";
-var name = file.substr(file.lastIndexOf("/") + 1);
+const file =  "/some/local/file/path/and/file/name.jpg";
+const url = "https://some.remote.service.com/path";
+const name = file.substr(file.lastIndexOf("/") + 1);
 
 // upload configuration
-var bghttp = require("nativescript-background-http");
-var session = bghttp.session("image-upload");
-var request = {
+const bghttp = require("nativescript-background-http");
+const session = bghttp.session("image-upload");
+const request = {
         url: url,
         method: "POST",
         headers: {
@@ -43,23 +49,28 @@ var request = {
 For a single file upload, use the following code:
 
 ```JavaScript
-var task = session.uploadFile(file, request);
+session.uploadFile(file, request).then( (task) => { /* Do something with Task */ });
 ```
 
 For multiple files or to pass additional data, use the multipart upload method. All parameter values must be strings:
 
 ```JavaScript
-var params = [
+const params = [
    { name: "test", value: "value" },
    { name: "fileToUpload", filename: file, mimeType: "image/jpeg" }
 ];
-var task = session.multipartUpload(params, request);
+session.multipartUpload(params, request).then( (task) => { /* Do something with Task */ } );
 ```
 
 In order to have a successful upload, the following must be taken into account:
 
 - the file must be accessible from your app. This may require additional permissions (e.g. access documents and files on the device). Usually this is not a problem - e.g. if you use another plugin to select the file, which already adds the required permissions.
 - the URL must not be blocked by the OS. Android Pie or later devices require TLS (HTTPS) connection by default and will not upload to an insecure (HTTP) URL.
+- If you are going to upload or allow uploading assets-library urls on iOS (i.e. URL's received from the Gallery) you need to add the following to your ios's Info.plist file:
+```
+<key>NSPhotoLibraryUsageDescription</key>^M
+<string>Requires access to photo library.</string>^M
+``` 
 
 ### Upload request and task API
 
@@ -120,7 +131,7 @@ function progressHandler(e) {
 // response: net.gotev.uploadservice.ServerResponse (Android) / NSHTTPURLResponse (iOS)
 function errorHandler(e) {
     alert("received " + e.responseCode + " code.");
-    var serverResponse = e.response;
+    let serverResponse = e.response;
 }
 
 
@@ -138,7 +149,7 @@ function respondedHandler(e) {
 // response: net.gotev.uploadservice.ServerResponse (Android) / NSHTTPURLResponse (iOS)
 function completeHandler(e) {
     alert("received " + e.responseCode + " code");
-    var serverResponse = e.response;
+    let serverResponse = e.response;
 }
 
 // event arguments:

--- a/demo-angular/app/App_Resources/iOS/Info.plist
+++ b/demo-angular/app/App_Resources/iOS/Info.plist
@@ -48,5 +48,7 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
   </dict>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Requires access to photo library.</string>
 </dict>
 </plist>

--- a/demo-angular/app/home/home.component.ts
+++ b/demo-angular/app/home/home.component.ts
@@ -63,7 +63,7 @@ export class HomeComponent {
             request.headers["Should-Fail"] = true;
         }
 
-        let task: bgHttp.Task;
+        let taskPromise: Promise<bgHttp.Task>;
         let lastEvent = "";
         if (isMulti) {
             const params = [
@@ -72,9 +72,9 @@ export class HomeComponent {
                 { name: "bool", value: true },
                 { name: "fileToUpload", filename: this.file, mimeType: 'image/jpeg' }
             ];
-            task = this.session.multipartUpload(params, request);
+            taskPromise = this.session.multipartUpload(params, request);
         } else {
-            task = this.session.uploadFile(this.file, request);
+            taskPromise = this.session.uploadFile(this.file, request);
         }
 
         function onEvent(e) {
@@ -97,11 +97,14 @@ export class HomeComponent {
             });
         }
 
-        task.on("progress", onEvent.bind(this));
-        task.on("error", onEvent.bind(this));
-        task.on("responded", onEvent.bind(this));
-        task.on("complete", onEvent.bind(this));
-        lastEvent = "";
-        this.tasks.push(task);
+        taskPromise.then( (task: bgHttp.Task) =>
+        {
+            task.on("progress", onEvent.bind(this));
+            task.on("error", onEvent.bind(this));
+            task.on("responded", onEvent.bind(this));
+            task.on("complete", onEvent.bind(this));
+            lastEvent = "";
+            this.tasks.push(task);
+        });
     }
 }

--- a/demo-server/package.json
+++ b/demo-server/package.json
@@ -5,6 +5,7 @@
     "start": "npm i && node server.js 8080"
   },
   "dependencies": {
+    "formidable": "^1.2.2",
     "stream-throttle": "*"
   }
 }

--- a/demo-vue/app/App_Resources/iOS/Info.plist
+++ b/demo-vue/app/App_Resources/iOS/Info.plist
@@ -52,5 +52,7 @@
 			<key>NSAllowsArbitraryLoads</key>
 			<true/>
 	</dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Requires access to photo library.</string>
 </dict>
 </plist>

--- a/demo-vue/app/components/Home.vue
+++ b/demo-vue/app/components/Home.vue
@@ -87,7 +87,7 @@ export default {
         request.headers["Should-Fail"] = true;
       }
 
-      let task; // bgHttp.Task;
+      let taskPromise; // Promise<Task>
       let lastEvent = "";
 
       if (isMulti) {
@@ -97,9 +97,9 @@ export default {
           { name: "bool", value: true },
           { name: "fileToUpload", filename: this.file, mimeType: 'image/jpeg' }
         ];
-        task = this.session.multipartUpload(params, request);
+        taskPromise = this.session.multipartUpload(params, request);
       } else {
-        task = this.session.uploadFile(this.file, request);
+        taskPromise = this.session.uploadFile(this.file, request);
       }
 
       function onEvent(e) {
@@ -124,13 +124,15 @@ export default {
         this.$set(this.tasks, this.tasks.indexOf(task), task);
       }
 
-      task.on("progress", onEvent.bind(this));
-      task.on("error", onEvent.bind(this));
-      task.on("responded", onEvent.bind(this));
-      task.on("complete", onEvent.bind(this));
-      lastEvent = "";
+      taskPromise.then( (task) => {
+        task.on("progress", onEvent.bind(this));
+        task.on("error", onEvent.bind(this));
+        task.on("responded", onEvent.bind(this));
+        task.on("complete", onEvent.bind(this));
+        lastEvent = "";
+        this.tasks.push(task);
+      });
 
-      this.tasks.push(task);
     },
     onItemLoading(args) {
       let label = args.view.getViewById("imageLabel");

--- a/demo/app/App_Resources/iOS/Info.plist
+++ b/demo/app/App_Resources/iOS/Info.plist
@@ -48,5 +48,7 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
   </dict>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Requires access to photo library.</string>
 </dict>
 </plist>

--- a/demo/app/home/home-view-model.ts
+++ b/demo/app/home/home-view-model.ts
@@ -63,7 +63,7 @@ export class HomeViewModel extends Observable {
             request.headers["Should-Fail"] = true;
         }
 
-        let task: bghttp.Task;
+        let taskPromise: Promise<bghttp.Task>;
         let lastEvent = "";
         if (isMulti) {
             const params = [
@@ -72,9 +72,9 @@ export class HomeViewModel extends Observable {
                 { name: "bool", value: true },
                 { name: "fileToUpload", filename: this.file, mimeType: 'image/jpeg' }
             ];
-            task = this.session.multipartUpload(params, request);
+            taskPromise = this.session.multipartUpload(params, request);
         } else {
-            task = this.session.uploadFile(this.file, request);
+            taskPromise = this.session.uploadFile(this.file, request);
         }
 
         function onEvent(e) {
@@ -97,11 +97,13 @@ export class HomeViewModel extends Observable {
             });
         }
 
-        task.on("progress", onEvent.bind(this));
-        task.on("error", onEvent.bind(this));
-        task.on("responded", onEvent.bind(this));
-        task.on("complete", onEvent.bind(this));
-        lastEvent = "";
-        this.tasks.push(task);
+        taskPromise.then( (task: bghttp.Task ) => {
+            task.on("progress", onEvent.bind(this));
+            task.on("error", onEvent.bind(this));
+            task.on("responded", onEvent.bind(this));
+            task.on("complete", onEvent.bind(this));
+            lastEvent = "";
+            this.tasks.push(task);
+        });
     }
 }

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -1,4 +1,5 @@
-scripts/*
+scripts/
+typings/*
 *.map
 /node_modules
 *.ts

--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -149,12 +149,12 @@ class Session {
         this._id = id;
     }
 
-    public uploadFile(fileUri: string, options: common.Request): Task {
-        return Task.create(this, fileUri, options);
+    public uploadFile(fileUri: string, options: common.Request): Promise<Task> {
+            return Promise.resolve( Task.create(this, fileUri, options) );
     }
 
-    public multipartUpload(params: Array<any>, options: common.Request): Task {
-        return Task.createMultiPart(this, params, options);
+    public multipartUpload(params: Array<any>, options: common.Request): Promise<Task> {
+            return Promise.resolve( Task.createMultiPart(this, params, options) );
     }
 
     get id(): string {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -135,8 +135,8 @@ export interface Session {
      * @param fileUri A file path to upload.
      * @param options Options for the upload, sets uri, headers, task description etc.
      */
-    uploadFile(fileUri: string, options: Request): Task;
-    multipartUpload(params: Array<any>, options: Request): Task;
+    uploadFile(fileUri: string, options: Request): Promise<Task>;
+    multipartUpload(params: Array<any>, options: Request): Promise<Task>;
 
 }
 


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
On iOS all assets-library urls are unable to be uploaded; normally you will get an assets-library url from a Gallery picker.

## What is the new behavior?
1. `assets-library://` urls are detected and are able to be uploaded.
  - PHAsset based urls should be able to now be easily added to the code base, as the `assets-library` urls are converted to the modern PHAsset. 
2. demo-server now handles multipart properly so we can verify everything is correctly built and uploaded.
3. Multipart uploads now handle multiple large files without running out of memory as all changes are now streamed to disk directly rather than to a large memory pointer (which was then written)...


Fixes/Implements/Closes #[Issue Number].
N/A

**BREAKING CHANGES:**
`uploadFile` / `multipartUpload` now return a PROMISE instead of a task.   The Promise will resolve with the task.  However, the process to ask iOS for permission to access the gallery item and retrieve the item from the PHAsset system requires callbacks; requiring that these now return a promise that retrieves the task so that the task can still be created properly...

**Migration steps:**
Change 
```
let task = uploadFile(...)
// All your older code
```

to

```
let promiseTask = uploadFile(...);
promiseTask.then( (task) => {
   // All your older code
});
```

or 

```
let task = await uploadFile(...);
// All your older code
```


