### PR TITLE
fix(android-request): Set custom user-agent from headers on Android request

### DIFF
--- a/src/background-http.android.ts
+++ b/src/background-http.android.ts
@@ -340,7 +340,11 @@ function setRequestOptions(request: any, options: common.Request) {
         for (const header in headers) {
             const value = headers[header];
             if (value !== null && value !== void 0) {
-                request.addHeader(header, value.toString());
+                if (header == 'User-Agent') {
+                    request.setCustomUserAgent(value.toString());
+                } else {
+                    request.addHeader(header, value.toString());
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

The `User-Agent` header field is ignored on Android.

## What is the new behavior?

The method `request.setCustomUserAgent` gets invoked copying the value from its correspondending header field.

<!-- Fixes/Implements/Closes #[Issue Number].-->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

